### PR TITLE
chore: use `dprint` for formatting

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,0 +1,39 @@
+{
+  "typescript": {
+    "quoteStyle": "preferSingle",
+  },
+  "json": {
+    "jsonTrailingCommaFiles": [
+      ".vscode/extensions.json",
+      ".vscode/settings.json",
+      "tsconfig.json",
+    ],
+  },
+  "markdown": {
+  },
+  "toml": {
+  },
+  "malva": {
+  },
+  "markup": {
+  },
+  "yaml": {
+  },
+  "excludes": [
+    "**/node_modules",
+    "**/*-lock.json",
+    "pnpm-lock.yaml",
+
+    ".rslib/**",
+    "dist/**",
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.95.11.wasm",
+    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.19.0.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    "https://plugins.dprint.dev/g-plane/malva-v0.14.3.wasm",
+    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.24.0.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
+  ],
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["biomejs.biome"]
+  "recommendations": ["biomejs.biome", "dprint.dprint"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,18 @@
 {
   "search.useIgnoreFiles": true,
   "[json]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "dprint.dprint",
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "dprint.dprint",
   },
   "[javascript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "dprint.dprint",
   },
   "[javascriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "dprint.dprint",
   },
   "[css]": {
-    "editor.defaultFormatter": "biomejs.biome"
-  }
+    "editor.defaultFormatter": "dprint.dprint",
+  },
 }

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ npm add rsbuild-plugin-mcp -D
 Add plugin to your `rsbuild.config.ts`:
 
 ```ts
-import { defineConfig } from '@rsbuild/core'
-import { pluginMCP } from 'rsbuild-plugin-mcp'
+import { defineConfig } from '@rsbuild/core';
+import { pluginMCP } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
   plugins: [pluginMCP()],
-})
+});
 ```
 
 ## Customize the MCP server
@@ -38,43 +38,43 @@ The MCP server can be extended with the following ways:
 Use the `mcpServerSetup` to customize the MCP server.
 
 ```ts
-import { defineConfig } from '@rsbuild/core'
-import { pluginMCP } from 'rsbuild-plugin-mcp'
+import { defineConfig } from '@rsbuild/core';
+import { pluginMCP } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
   plugins: [
     pluginMCP({
       mcpServerSetup(mcpServer) {
         // Register tools, resources and prompts
-        mcpServer.tool(/** args */)
-        mcpServer.resource(/** args */)
-        mcpServer.prompt(/** args */)
+        mcpServer.tool(); /** args */
+        mcpServer.resource(); /** args */
+        mcpServer.prompt(); /** args */
       },
     }),
   ],
-})
+});
 ```
 
 You may also return a new `McpServer` instance to replace the default one:
 
 ```js
-import { defineConfig } from '@rsbuild/core'
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { pluginMCP } from 'rsbuild-plugin-mcp'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { defineConfig } from '@rsbuild/core';
+import { pluginMCP } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
   plugins: [
     pluginMCP({
       mcpServerSetup() {
         // Create a new `McpServer` and return
-        const mcpServer = new McpServer()
+        const mcpServer = new McpServer();
         // Register tools, resources and prompts
-        mcpServer.tool()
-        return mcpServer
+        mcpServer.tool();
+        return mcpServer;
       },
     }),
   ],
-})
+});
 ```
 
 ### With other plugins

--- a/biome.json
+++ b/biome.json
@@ -8,22 +8,17 @@
     "useIgnoreFile": true
   },
   "formatter": {
-    "indentStyle": "space"
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single"
-    }
-  },
-  "css": {
-    "formatter": {
-      "enabled": true
-    }
+    "enabled": false
   },
   "linter": {
     "enabled": true,
     "rules": {
       "recommended": true
+    }
+  },
+  "json": {
+    "parser": {
+      "allowTrailingCommas": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "build": "rslib build",
     "bump": "npx bumpp",
     "dev": "rslib build --watch",
-    "lint": "biome check .",
-    "lint:write": "biome check . --write",
+    "lint": "dprint check && biome check .",
+    "lint:write": "dprint fmt && biome check . --write",
     "prepare": "simple-git-hooks && npm run build",
     "test": "rstest"
   },
@@ -39,6 +39,7 @@
     "@rslib/core": "^0.15.0",
     "@rstest/core": "^0.5.1",
     "@types/node": "^22.18.8",
+    "dprint": "^0.50.2",
     "simple-git-hooks": "^2.13.1",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.18.8
         version: 22.18.8
+      dprint:
+        specifier: ^0.50.2
+        version: 0.50.2
       simple-git-hooks:
         specifier: ^2.13.1
         version: 2.13.1
@@ -146,6 +149,51 @@ packages:
   '@biomejs/cli-win32-x64@2.2.4':
     resolution: {integrity: sha512-3Y4V4zVRarVh/B/eSHczR4LYoSVyv3Dfuvm3cWs5w/HScccS0+Wt/lHOcDTRYeHjQmMYVC3rIRWqyN2EI52+zg==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@dprint/darwin-arm64@0.50.2':
+    resolution: {integrity: sha512-4d08INZlTxbPW9LK9W8+93viN543/qA2Kxn4azVnPW/xCb2Im03UqJBz8mMm3nJZdtNnK3uTVG3ib1VW+XJisw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@dprint/darwin-x64@0.50.2':
+    resolution: {integrity: sha512-ZXWPBwdLojhdBATq+bKwJvB7D8bIzrD6eR/Xuq9UYE7evQazUiR069d9NPF0iVuzTo6wNf9ub9SXI7qDl11EGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@dprint/linux-arm64-glibc@0.50.2':
+    resolution: {integrity: sha512-marxQzRw8atXAnaawwZHeeUaaAVewrGTlFKKcDASGyjPBhc23J5fHPUPremm8xCbgYZyTlokzrV8/1rDRWhJcw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@dprint/linux-arm64-musl@0.50.2':
+    resolution: {integrity: sha512-oGDq44ydzo0ZkJk6RHcUzUN5sOMT5HC6WA8kHXI6tkAsLUkaLO2DzZFfW4aAYZUn+hYNpQfQD8iGew0sjkyLyg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@dprint/linux-riscv64-glibc@0.50.2':
+    resolution: {integrity: sha512-QMmZoZYWsXezDcC03fBOwPfxhTpPEyHqutcgJ0oauN9QcSXGji9NSZITMmtLz2Ki3T1MIvdaLd1goGzNSvNqTQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@dprint/linux-x64-glibc@0.50.2':
+    resolution: {integrity: sha512-KMeHEzb4teQJChTgq8HuQzc+reRNDnarOTGTQovAZ9WNjOtKLViftsKWW5HsnRHtP5nUIPE9rF1QLjJ/gUsqvw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@dprint/linux-x64-musl@0.50.2':
+    resolution: {integrity: sha512-qM37T7H69g5coBTfE7SsA+KZZaRBky6gaUhPgAYxW+fOsoVtZSVkXtfTtQauHTpqqOEtbxfCtum70Hz1fr1teg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@dprint/win32-arm64@0.50.2':
+    resolution: {integrity: sha512-kuGVHGoxLwssVDsodefUIYQRoO2fQncurH/xKgXiZwMPOSzFcgUzYJQiyqmJEp+PENhO9VT1hXUHZtlyCAWBUQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@dprint/win32-x64@0.50.2':
+    resolution: {integrity: sha512-N3l9k31c3IMfVXqL0L6ygIhJFvCIrfQ+Z5Jph6RnCcBO6oDYWeYhAv/qBk1vLsF2y/e79TKsR1tvaEwnrQ03XA==}
     cpu: [x64]
     os: [win32]
 
@@ -501,6 +549,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dprint@0.50.2:
+    resolution: {integrity: sha512-+0Fzg+17jsMMUouK00/Fara5YtGOuE76EAJINHB8VpkXHd0n00rMXtw/03qorOgz23eo8Y0UpYvNZBJJo3aNtw==}
+    hasBin: true
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -990,6 +1042,33 @@ snapshots:
   '@biomejs/cli-win32-x64@2.2.4':
     optional: true
 
+  '@dprint/darwin-arm64@0.50.2':
+    optional: true
+
+  '@dprint/darwin-x64@0.50.2':
+    optional: true
+
+  '@dprint/linux-arm64-glibc@0.50.2':
+    optional: true
+
+  '@dprint/linux-arm64-musl@0.50.2':
+    optional: true
+
+  '@dprint/linux-riscv64-glibc@0.50.2':
+    optional: true
+
+  '@dprint/linux-x64-glibc@0.50.2':
+    optional: true
+
+  '@dprint/linux-x64-musl@0.50.2':
+    optional: true
+
+  '@dprint/win32-arm64@0.50.2':
+    optional: true
+
+  '@dprint/win32-x64@0.50.2':
+    optional: true
+
   '@emnapi/core@1.5.0':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -1405,6 +1484,18 @@ snapshots:
       ms: 2.1.3
 
   depd@2.0.0: {}
+
+  dprint@0.50.2:
+    optionalDependencies:
+      '@dprint/darwin-arm64': 0.50.2
+      '@dprint/darwin-x64': 0.50.2
+      '@dprint/linux-arm64-glibc': 0.50.2
+      '@dprint/linux-arm64-musl': 0.50.2
+      '@dprint/linux-riscv64-glibc': 0.50.2
+      '@dprint/linux-x64-glibc': 0.50.2
+      '@dprint/linux-x64-musl': 0.50.2
+      '@dprint/win32-arm64': 0.50.2
+      '@dprint/win32-x64': 0.50.2
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,11 @@
 packages:
   - playground
 
-onlyBuiltDependencies:
+ignoredBuiltDependencies:
   - core-js
+  - dprint
+
+onlyBuiltDependencies:
   - simple-git-hooks
+
+strictDepBuilds: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,9 +69,7 @@ export const pluginMCP = (options?: PluginMCPOptions): RsbuildPlugin => ({
   apply: 'serve',
 
   async setup(api) {
-    let mcpServer = await import('./server.js').then(({ createMcpServer }) =>
-      createMcpServer(api),
-    );
+    let mcpServer = await import('./server.js').then(({ createMcpServer }) => createMcpServer(api));
 
     mcpServer = (await options?.mcpServerSetup(mcpServer)) ?? mcpServer;
     api.expose('rsbuild-plugin-mcp:mcpServer', mcpServer);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "module": "Node18",
-    "moduleResolution": "Node16"
+    "moduleResolution": "Node16",
   },
-  "include": ["src"]
+  "include": ["src"],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Adopted dprint as the default formatter, added it to development dependencies, and updated lint scripts to use it.
  * Updated editor recommendations and settings to align with the new formatter.
  * Tightened workspace build settings, separating ignored vs. built dependencies and enabling strict builds.

* Style
  * Repository-wide formatting updates, including consistent semicolons, trailing commas, and streamlined import/call expressions.

* Documentation
  * Refreshed README code examples for consistent formatting without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->