### PR TITLE
feat: add `mcpRouteRoot` option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,7 @@
   "[css]": {
     "editor.defaultFormatter": "dprint.dprint",
   },
+  "[markdown]": {
+    "editor.defaultFormatter": "dprint.dprint",
+  },
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ export default defineConfig({
 });
 ```
 
+## Options
+
+### `mcpRouteRoot`
+
+- Type: `string | undefined`
+- Default: `/__mcp`
+
+Customize the routes of the MCP server.
+
+- Example:
+
+```ts
+import { defineConfig } from '@rsbuild/core';
+import { pluginMCP } from 'rsbuild-plugin-mcp';
+
+export default defineConfig({
+  plugins: [
+    pluginMCP({
+      mcpRouteRoot: '/api/__mcp',
+    }),
+  ],
+});
+```
+
 ## Customize the MCP server
 
 The MCP server can be extended with the following ways:

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ type MaybePromise<T> = T | Promise<T>;
 
 export interface PluginMCPOptions {
   /**
+   * The root route to the MCP server. Defaults to `/__mcp`.
+   */
+  mcpRouteRoot?: string | undefined;
+
+  /**
    * Setup the MCP server, this is called when the MCP server is created.
    *
    * @example
@@ -58,7 +63,7 @@ export interface PluginMCPOptions {
    *
    * @returns If a new MCP server is returned, it will replace the default one.
    */
-  mcpServerSetup: (
+  mcpServerSetup?: (
     mcpServer: McpServer,
   ) => MaybePromise<void> | MaybePromise<McpServer>;
 }
@@ -71,11 +76,10 @@ export const pluginMCP = (options?: PluginMCPOptions): RsbuildPlugin => ({
   async setup(api) {
     let mcpServer = await import('./server.js').then(({ createMcpServer }) => createMcpServer(api));
 
-    mcpServer = (await options?.mcpServerSetup(mcpServer)) ?? mcpServer;
+    mcpServer = (await options?.mcpServerSetup?.(mcpServer)) ?? mcpServer;
     api.expose('rsbuild-plugin-mcp:mcpServer', mcpServer);
 
-    // TODO: make this configurable
-    const base = '/__mcp';
+    const base = options?.mcpRouteRoot ?? '/__mcp';
 
     const { setupRoutes } = await import('./connect.js');
     setupRoutes(api, base, mcpServer);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -111,5 +111,26 @@ describe('Config', () => {
         handle: expect.any(Function),
       });
     });
+
+    test('mcpRouteRoot', async () => {
+      const { pluginMCP } = await import('../src/index.js');
+      const rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          plugins: [pluginMCP({ mcpRouteRoot: '/foo' })],
+        },
+      });
+
+      const server = await rsbuild.createDevServer({
+        runCompile: false,
+      });
+      expect(server.middlewares.stack).toContainEqual({
+        route: '/foo/sse',
+        handle: expect.any(Function),
+      });
+      expect(server.middlewares.stack).toContainEqual({
+        route: '/foo/messages',
+        handle: expect.any(Function),
+      });
+    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to customize the MCP base route via mcpRouteRoot (defaults to /__mcp).
  * Made the MCP server setup hook optional in plugin configuration.

* **Documentation**
  * Updated README with details, defaults, and examples for configuring mcpRouteRoot.

* **Tests**
  * Added tests validating custom MCP route paths are correctly registered.

* **Chores**
  * Updated editor settings to apply consistent formatting to Markdown files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->