### PR TITLE
refactor!: rename `pluginMCP` to `pluginMcp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Add plugin to your `rsbuild.config.ts`:
 
 ```ts
 import { defineConfig } from '@rsbuild/core';
-import { pluginMCP } from 'rsbuild-plugin-mcp';
+import { pluginMcp } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
-  plugins: [pluginMCP()],
+  plugins: [pluginMcp()],
 });
 ```
 
@@ -42,11 +42,11 @@ Customize the routes of the MCP server.
 
 ```ts
 import { defineConfig } from '@rsbuild/core';
-import { pluginMCP } from 'rsbuild-plugin-mcp';
+import { pluginMcp } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
   plugins: [
-    pluginMCP({
+    pluginMcp({
       mcpRouteRoot: '/api/__mcp',
     }),
   ],
@@ -63,11 +63,11 @@ Use the `mcpServerSetup` to customize the MCP server.
 
 ```ts
 import { defineConfig } from '@rsbuild/core';
-import { pluginMCP } from 'rsbuild-plugin-mcp';
+import { pluginMcp } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
   plugins: [
-    pluginMCP({
+    pluginMcp({
       mcpServerSetup(mcpServer) {
         // Register tools, resources and prompts
         mcpServer.tool(); /** args */
@@ -84,11 +84,11 @@ You may also return a new `McpServer` instance to replace the default one:
 ```js
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { defineConfig } from '@rsbuild/core';
-import { pluginMCP } from 'rsbuild-plugin-mcp';
+import { pluginMcp } from 'rsbuild-plugin-mcp';
 
 export default defineConfig({
   plugins: [
-    pluginMCP({
+    pluginMcp({
       mcpServerSetup() {
         // Create a new `McpServer` and return
         const mcpServer = new McpServer();

--- a/playground/rsbuild.config.ts
+++ b/playground/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
-import { pluginMCP } from '../src';
+import { pluginMcp } from '../src';
 
 export default defineConfig({
-  plugins: [pluginMCP()],
+  plugins: [pluginMcp()],
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 
 type MaybePromise<T> = T | Promise<T>;
 
-export interface pluginMcpOptions {
+export interface PluginMcpOptions {
   /**
    * The root route to the MCP server. Defaults to `/__mcp`.
    */
@@ -68,7 +68,7 @@ export interface pluginMcpOptions {
   ) => MaybePromise<void> | MaybePromise<McpServer>;
 }
 
-export const pluginMcp = (options?: pluginMcpOptions): RsbuildPlugin => ({
+export const pluginMcp = (options?: PluginMcpOptions): RsbuildPlugin => ({
   name: 'plugin-mcp',
 
   apply: 'serve',

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 
 type MaybePromise<T> = T | Promise<T>;
 
-export interface PluginMCPOptions {
+export interface pluginMcpOptions {
   /**
    * The root route to the MCP server. Defaults to `/__mcp`.
    */
@@ -18,11 +18,11 @@ export interface PluginMCPOptions {
    *
    * ```js
    * import { defineConfig } from '@rsbuild/core'
-   * import { pluginMCP } from 'rsbuild-plugin-mcp'
+   * import { pluginMcp } from 'rsbuild-plugin-mcp'
    *
    * export default defineConfig({
    *   plugins: [
-   *     pluginMCP({
+   *     pluginMcp({
    *       mcpServerSetup(mcpServer) {
    *         // Register tools, resources and prompts
    *         mcpServer.tool()
@@ -41,11 +41,11 @@ export interface PluginMCPOptions {
    * ```js
    * import { defineConfig } from '@rsbuild/core'
    * import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-   * import { pluginMCP } from 'rsbuild-plugin-mcp'
+   * import { pluginMcp } from 'rsbuild-plugin-mcp'
    *
    * export default defineConfig({
    *   plugins: [
-   *     pluginMCP({
+   *     pluginMcp({
    *       mcpServerSetup() {
    *         // Create a new `McpServer` and return
    *         const mcpServer = new McpServer()
@@ -68,7 +68,7 @@ export interface PluginMCPOptions {
   ) => MaybePromise<void> | MaybePromise<McpServer>;
 }
 
-export const pluginMCP = (options?: PluginMCPOptions): RsbuildPlugin => ({
+export const pluginMcp = (options?: pluginMcpOptions): RsbuildPlugin => ({
   name: 'plugin-mcp',
 
   apply: 'serve',
@@ -108,3 +108,8 @@ export const pluginMCP = (options?: PluginMCPOptions): RsbuildPlugin => ({
     });
   },
 });
+
+/**
+ * @deprecated - Use {@link pluginMcp} instead.
+ */
+export const pluginMCP = pluginMcp;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,10 +3,10 @@ import { assert, describe, expect, rstest, test } from '@rstest/core';
 
 describe('Config', () => {
   test('should not apply plugin when build', async () => {
-    const { pluginMCP } = await import('../src/index.js');
+    const { pluginMcp } = await import('../src/index.js');
     const rsbuild = await createRsbuild({
       rsbuildConfig: {
-        plugins: [pluginMCP()],
+        plugins: [pluginMcp()],
       },
     });
 
@@ -17,13 +17,13 @@ describe('Config', () => {
 
   describe('printUrls', () => {
     test('should respect server.printUrls = false', async () => {
-      const { pluginMCP } = await import('../src/index.js');
+      const { pluginMcp } = await import('../src/index.js');
       const rsbuild = await createRsbuild({
         rsbuildConfig: {
           server: {
             printUrls: false,
           },
-          plugins: [pluginMCP()],
+          plugins: [pluginMcp()],
         },
       });
 
@@ -33,10 +33,10 @@ describe('Config', () => {
     });
 
     test('should append MCP url to printed urls', async () => {
-      const { pluginMCP } = await import('../src/index.js');
+      const { pluginMcp } = await import('../src/index.js');
       const rsbuild = await createRsbuild({
         rsbuildConfig: {
-          plugins: [pluginMCP()],
+          plugins: [pluginMcp()],
         },
       });
 
@@ -56,10 +56,10 @@ describe('Config', () => {
         .fn()
         .mockReturnValue(['http://localhost:3000', 'https://example.com']);
 
-      const { pluginMCP } = await import('../src/index.js');
+      const { pluginMcp } = await import('../src/index.js');
       const rsbuild = await createRsbuild({
         rsbuildConfig: {
-          plugins: [pluginMCP()],
+          plugins: [pluginMcp()],
           server: {
             printUrls: fn,
           },
@@ -84,10 +84,10 @@ describe('Config', () => {
 
   describe('Server', () => {
     test('should have middleware routes registered', async () => {
-      const { pluginMCP } = await import('../src/index.js');
+      const { pluginMcp } = await import('../src/index.js');
       const rsbuild = await createRsbuild({
         rsbuildConfig: {
-          plugins: [pluginMCP()],
+          plugins: [pluginMcp()],
         },
       });
       const rawRsbuild = await createRsbuild();
@@ -113,10 +113,10 @@ describe('Config', () => {
     });
 
     test('mcpRouteRoot', async () => {
-      const { pluginMCP } = await import('../src/index.js');
+      const { pluginMcp } = await import('../src/index.js');
       const rsbuild = await createRsbuild({
         rsbuildConfig: {
-          plugins: [pluginMCP({ mcpRouteRoot: '/foo' })],
+          plugins: [pluginMcp({ mcpRouteRoot: '/foo' })],
         },
       });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Renamed the public API from pluginMCP to pluginMcp for consistency.
  * Added a deprecated alias pluginMCP to preserve compatibility; prefer pluginMcp going forward.
  * No functional behavior changes.

* Documentation
  * Updated README examples to reflect the pluginMcp import and usage.

* Tests
  * Updated test imports and registrations to use pluginMcp to match the new API name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->